### PR TITLE
Implement Zero-Dependency JWT Generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#14](https://github.com/blackjacx/engine/pull/14): Implement Zero-Dependency JWT Generation - [@Blackjacx](https://github.com/blackjacx).
 * Fix Testing GH Actions workflow - [@Blackjacx](https://github.com/blackjacx).
 * Moving Quickie Package here - [@Blackjacx](https://github.com/blackjacx).
 * Fix GH Actions Tests - [@Blackjacx](https://github.com/blackjacx).

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftKeychainWrapper",
+        "repositoryURL": "https://github.com/jrendel/SwiftKeychainWrapper",
+        "state": {
+          "branch": null,
+          "revision": "185a3165346a03767101c4f62e9a545a0fe0530f",
+          "version": "4.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,10 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(
     name: "Engine",
     platforms: [
-        .macOS(.v12),
-        .macCatalyst(.v15),
+        .macOS(.v13),
         .iOS(.v15),
         .tvOS(.v15),
         .watchOS(.v8)
@@ -13,9 +12,17 @@ let package = Package(
     products: [
         .library(name: "Engine", targets: ["Engine"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/jrendel/SwiftKeychainWrapper", from: "4.0.1")
+    ],
     targets: [
-        .target(name: "Engine"),
-        .testTarget(name: "EngineTests", dependencies: ["Engine"])
+        .target(
+            name: "Engine",
+            dependencies: ["SwiftKeychainWrapper"]
+        ),
+        .testTarget(
+            name: "EngineTests",
+            dependencies: ["Engine"]
+        )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <!-- [![Test](https://github.com/Blackjacx/Engine/actions/workflows/test.yml/badge.svg)](https://github.com/Blackjacx/Engine/actions/workflows/test.yml) -->
-[![Twitter Follow](https://img.shields.io/badge/Follow-%40Blackjacx-1DA1F2?logo=twitter)](https://twitter.com/intent/follow?original_referer=https%3A%2F%2Fgithub.com%2Fblackjacx&screen_name=Blackjacxxx)
+[![X Follow](https://img.shields.io/badge/Follow-%40Blackjacx-1DA1F2?logo=twitter)](https://twitter.com/intent/follow?original_referer=https%3A%2F%2Fgithub.com%2Fblackjacx&screen_name=Blackjacxxx)
 [![Version](https://shields.io/github/v/release/blackjacx/Engine?display_name=tag&include_prereleases&sort=semver)](https://github.com/Blackjacx/Engine/releases)
 [![Swift Package Manager Compatible](https://img.shields.io/badge/SPM-compatible-brightgreen.svg)](https://swift.org/package-manager/)
 [![Swift Versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FBlackjacx%2FEngine%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/Blackjacx/Engine)
 [![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FBlackjacx%2FEngine%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/Blackjacx/Engine)
-[![Xcode 13+](https://img.shields.io/badge/Xcode-13%2B-blue.svg)](https://developer.apple.com/download/)
+[![Xcode 16+](https://img.shields.io/badge/Xcode-16%2B-blue.svg)](https://developer.apple.com/download/)
 [![Codebeat](https://codebeat.co/badges/c1452aaa-260a-421a-8f1a-5b51ab3ad316)](https://codebeat.co/projects/github-com-blackjacx-engine-develop)
 [![License](https://img.shields.io/github/license/blackjacx/engine.svg)](https://github.com/blackjacx/engine/blob/main/LICENSE)
 [![Donate PayPal](https://img.shields.io/badge/Donate-PayPal-0079c1?logo=paypal)](https://www.paypal.me/STHEROLD)

--- a/Sources/Engine/Engine.swift
+++ b/Sources/Engine/Engine.swift
@@ -7,3 +7,7 @@
 
 import Foundation
 
+struct Engine {
+    /// Global keychain
+    public static var keychain = Keychain()
+}

--- a/Sources/Engine/Foundation/String+Random.swift
+++ b/Sources/Engine/Foundation/String+Random.swift
@@ -62,7 +62,7 @@ public extension String {
         }
 
         let start = workingBase.startIndex
-        let end = workingBase.index(start, offsetBy: String.IndexDistance(Swift.max(length, 0)))
+        let end = workingBase.index(start, offsetBy: Swift.max(length, 0))
         return String(workingBase[start..<end])
     }
 

--- a/Sources/Engine/JWT/JWT.swift
+++ b/Sources/Engine/JWT/JWT.swift
@@ -1,0 +1,155 @@
+//
+//  JWT.swift
+//  Engine
+//
+//  Created by Stefan Herold on 17.02.2025.
+//
+
+import CryptoKit
+import Foundation
+
+public struct JWT {
+    public init() {}
+
+    public func create(keySource: KeySource, header: JWTHeader, payload: JWTClaims) async throws(Error) -> String {
+        let headerBase64: String
+        let payloadBase64: String
+
+        do {
+            let jsonEncoder = JSONEncoder()
+            jsonEncoder.dateEncodingStrategy = .custom({ date, encoder in
+                var container = encoder.singleValueContainer()
+                try container.encode(Int(date.timeIntervalSince1970))
+            })
+            let headerData = try jsonEncoder.encode(header)
+            let payloadData = try jsonEncoder.encode(payload)
+            headerBase64 = base64URLEncode(headerData)
+            payloadBase64 = base64URLEncode(payloadData)
+        } catch {
+            throw .headerOrPayloadEncodingError
+        }
+
+        guard let keyAsString = String(data: try keySource.data(), encoding: .utf8) else {
+            throw .privateKeyToStringConversionFailed
+        }
+        let privateKey: P256.Signing.PrivateKey
+        do {
+            privateKey = try P256.Signing.PrivateKey(pemRepresentation: keyAsString)
+        } catch {
+            throw .privateKeyInvalid
+        }
+
+        // Signing Input
+        let signingInput = "\(headerBase64).\(payloadBase64)"
+        let signingInputData = signingInput.data(using: .utf8)!
+
+        // Sign with existing key
+        let signature: P256.Signing.ECDSASignature
+        do {
+            signature = try privateKey.signature(for: signingInputData)
+        } catch {
+            throw .signingError
+        }
+        let signatureBase64 = base64URLEncode(signature.rawRepresentation)
+
+        // Construct final JWT
+        return "\(signingInput).\(signatureBase64)"
+    }
+
+    // MARK: - Private Helper Functions
+
+    private func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    // MARK: - Sub Types
+
+    public enum KeySource: Equatable, Hashable, Codable {
+        case localFilePath(path: String)
+        case keychain(keychainKey: String)
+        case inline(privateKey: String)
+
+        func data() throws(Error) -> Data {
+            switch self {
+            case .localFilePath(let path):
+                guard let data = FileManager.default.contents(atPath: path) else {
+                    throw .fileNotFound(path)
+                }
+                return data
+            case .keychain(let keychainKey):
+                guard let data = Engine.keychain.keychainItem(for: keychainKey)?.data(using: .utf8) else {
+                    throw .keychainItemNotFound(keychainKey)
+                }
+                return data
+            case .inline(let privateKey):
+                guard let data = privateKey.data(using: .utf8) else {
+                    throw .conversionFailed
+                }
+                return data
+            }
+        }
+
+        // MARK: - Codable
+
+        enum CodingKeys: CodingKey {
+            case localFilePath
+            case keychain
+            case inline
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let key = container.allKeys.first
+
+            switch key {
+            case .localFilePath:
+                let path = try container.decode(String.self, forKey: .localFilePath)
+                self = .localFilePath(path: path)
+            case .keychain:
+                let keychainKey = try container.decode(String.self, forKey: .keychain)
+                self = .keychain(keychainKey: keychainKey)
+            case .inline:
+                let privateKey = try container.decode(String.self, forKey: .inline)
+                self = .inline(privateKey: privateKey)
+            default:
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: container.codingPath,
+                        debugDescription: "Unable to decode enum."
+                    )
+                )
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            switch self {
+            case .localFilePath(let path):
+                try container.encode(path, forKey: .localFilePath)
+            case .keychain(let keychainKey):
+                try container.encode(keychainKey, forKey: .keychain)
+            case .inline(let privateKey):
+                try container.encode(privateKey, forKey: .inline)
+            }
+        }
+    }
+
+    public enum Error: Swift.Error {
+        case credentialsNotSet
+        case headerOrPayloadEncodingError
+        case signingError
+        case keychainItemNotFound(String)
+        case conversionFailed
+        case fileNotFound(String)
+        case privateKeyEmpty
+        case privateKeyToStringConversionFailed
+        case privateKeyInvalid
+        case keyContainsNoData(String)
+        case googleServiceAccountJsonNotFound(path: String)
+        case invalidResonse(response: URLResponse)
+    }
+}

--- a/Sources/Engine/JWT/JWTClaims.swift
+++ b/Sources/Engine/JWT/JWTClaims.swift
@@ -1,0 +1,16 @@
+//
+//  JWTClaims.swift
+//  Engine
+//
+//  Created by Stefan Herold on 17.02.2025.
+//
+
+import Foundation
+
+public protocol JWTClaims: Encodable {
+    var aud: String? { get }
+    // Creation date in time interval since 1970 casted to Int
+    var iat: Date { get }
+    // Expiration date in time interval since 1970 casted to Int
+    var exp: Date? { get }
+}

--- a/Sources/Engine/JWT/JWTHeader.swift
+++ b/Sources/Engine/JWT/JWTHeader.swift
@@ -1,0 +1,13 @@
+//
+//  JWTHeader.swift
+//  Engine
+//
+//  Created by Stefan Herold on 17.02.2025.
+//
+
+import Foundation
+
+public protocol JWTHeader: Encodable {
+    var alg: String? { get }
+    var typ: String { get }
+}

--- a/Sources/Engine/Keychain/Keychain.swift
+++ b/Sources/Engine/Keychain/Keychain.swift
@@ -1,0 +1,67 @@
+//
+//  Keychain.swift
+//  Engine
+//
+//  Created by Stefan Herold on 17.02.2025.
+//
+
+import Foundation
+import SwiftKeychainWrapper
+
+public struct Keychain {
+
+    private let keychain = KeychainWrapper(serviceName: ProcessInfo.processId)
+    private let persistentStore = UserDefaults.standard
+
+    /// The private store properties for our keychain items to not pull them
+    /// from the keychain if the app is still in memory. This allows us to
+    /// bypass the locked keychain when iPhone is locked and the app is just in
+    /// background.
+    private var transientStore: [String: String] = [:]
+
+    // MARK: - Public Interface
+
+    public mutating func setKeychainItem(_ value: String, key: String) -> Bool {
+
+        // Make sure to always set a Data object to the Keychain since
+        // otherwise storing an item will give you unexpected behaviour.
+        keychain.set(value, forKey: key)
+
+        guard keychain.string(forKey: key) == value else {
+            return false
+        }
+        transientStore[key] = value
+        persistentStore.set(true, forKey: key)
+
+        return true
+    }
+
+    public mutating func keychainItem(for key: String) -> String? {
+
+        let hasKeychainItem = persistentStore.bool(forKey: key)
+
+        guard hasKeychainItem else {
+            removeKeychainItem(for: key)
+            return nil
+        }
+
+        if let item = transientStore[key] {
+            return item
+        }
+
+        guard let value = keychain.string(forKey: key) else {
+            removeKeychainItem(for: key)
+            return nil
+        }
+
+        transientStore[key] = value
+        return value
+    }
+
+    public mutating func removeKeychainItem(for key: String) {
+
+        transientStore[key] = nil
+        persistentStore.setValue(nil, forKey: key)
+        keychain.removeObject(forKey: key)
+    }
+}

--- a/Tests/EngineTests/Foundation/URLTests.swift
+++ b/Tests/EngineTests/Foundation/URLTests.swift
@@ -6,20 +6,21 @@
 //
 
 import Foundation
-import XCTest
+import Testing
 @testable import Engine
 
-final class URLTests: XCTestCase {
+@Suite()
+struct URLTests {
 
-    func testConstructUrlEncodedUrlWithQuery() {
-
+    @Test("Construct URL Encoded URL with Query")
+    func constructUrlEncodedUrlWithQuery() async throws {
         let expected = "https://test.com/%C3%A4hm?z=12"
-
-        let url = URL.createFrom(scheme: "https",
-                                 host: "test.com",
-                                 path: "/ähm",
-                                 parameters: ["z": "12"])
-
-        XCTAssertEqual(url?.absoluteString, expected)
+        let url = URL.createFrom(
+            scheme: "https",
+            host: "test.com",
+            path: "/ähm",
+            parameters: ["z": "12"]
+        )
+        #expect(url?.absoluteString == expected)
     }
 }

--- a/Tests/EngineTests/JWT/JWTTests.swift
+++ b/Tests/EngineTests/JWT/JWTTests.swift
@@ -1,0 +1,44 @@
+//
+//  JWTTests.swift
+//  Engine
+//
+//  Created by Stefan Herold on 17.02.2025.
+//
+
+import Foundation
+import Testing
+@testable import Engine
+
+@Suite()
+struct JWTTests {
+
+    @Test("Generate JWT Token")
+    func createJWT() async throws {
+        let jwt = try await JWT().create(
+            // This is a fake test key ⚠️
+            keySource: .inline(privateKey: """
+            -----BEGIN EC PRIVATE KEY-----
+            MHcCAQEEIDRTZb3ZCTWxPb7VY4RxWx9T0X5z+9bG2xPGgAkGm/CioAoGCCqGSM49
+            AwEHoUQDQgAEdzhbmbV5zPuE5wUqhnAcDXhNJ5EJhFS5GG38YujrlPYoU2XHLm7n
+            TUN/qLvSK5Z7lzE6jfzv8mJwUMULKPm+0A==
+            -----END EC PRIVATE KEY-----
+            """),
+            header: ExampleHeader(kid: "8A7Q99KV2Y"),
+            payload: ExampleClaims(iss: "0E378B17-7CD6-4679-84D9-8061415FC07F")
+        )
+        #expect(jwt != nil)
+    }
+}
+
+private struct ExampleClaims: JWTClaims {
+    let aud: String? = "some-audience"
+    let iat: Date = Date()
+    let exp: Date? = Date().addingTimeInterval(60 * 60)
+    let iss: String
+}
+
+private struct ExampleHeader: JWTHeader {
+    let alg: String? = "ES256"
+    let typ: String = "JWT"
+    let kid: String
+}

--- a/Tests/EngineTests/PropertyWrapper/ClampingTests.swift
+++ b/Tests/EngineTests/PropertyWrapper/ClampingTests.swift
@@ -6,10 +6,11 @@
 //
 
 import Foundation
-import XCTest
+import Testing
 @testable import Engine
 
-final class ClampingTests: XCTestCase {
+@Suite()
+struct ClampingTests {
     static let min: Double = 0
     static let max: Double = 14
 
@@ -29,35 +30,37 @@ final class ClampingTests: XCTestCase {
         let overflowValue = Clamping(initialValue: max + 0.001, min...max)
     }
 
-    func testClampingOnWrappedValueInit() {
+    @Test("Clamping On Wrapped Value Init")
+    func clampingOnWrappedValueInit() async throws {
         var c1 = Collection1()
-        XCTAssertEqual(c1.underflowValue, Self.min)
-        XCTAssertEqual(c1.lowerEqualValue, Self.min)
-        XCTAssertEqual(c1.inRangeValue, 7)
-        XCTAssertEqual(c1.upperEqualValue, Self.max)
-        XCTAssertEqual(c1.overflowValue, Self.max)
+        #expect(c1.underflowValue == Self.min)
+        #expect(c1.lowerEqualValue == Self.min)
+        #expect(c1.inRangeValue == 7)
+        #expect(c1.upperEqualValue == Self.max)
+        #expect(c1.overflowValue == Self.max)
 
         c1.inRangeValue -= 100
-        XCTAssertEqual(c1.inRangeValue, Self.min)
+        #expect(c1.inRangeValue == Self.min)
         c1.inRangeValue = 7
-        XCTAssertEqual(c1.inRangeValue, 7)
+        #expect(c1.inRangeValue == 7)
         c1.inRangeValue += 100
-        XCTAssertEqual(c1.inRangeValue, Self.max)
+        #expect(c1.inRangeValue == Self.max)
     }
 
-    func testClampingOnAlternativeInit() {
+    @Test("Clamping On Alternative Init")
+    func clampingOnAlternativeInit() {
         var c2 = Collection2()
-        XCTAssertEqual(c2.underflowValue.value, Self.min)
-        XCTAssertEqual(c2.lowerEqualValue.value, Self.min)
-        XCTAssertEqual(c2.inRangeValue.value, 7)
-        XCTAssertEqual(c2.upperEqualValue.value, Self.max)
-        XCTAssertEqual(c2.overflowValue.value, Self.max)
+        #expect(c2.underflowValue.value == Self.min)
+        #expect(c2.lowerEqualValue.value == Self.min)
+        #expect(c2.inRangeValue.value == 7)
+        #expect(c2.upperEqualValue.value == Self.max)
+        #expect(c2.overflowValue.value == Self.max)
 
         c2.inRangeValue.value -= 100
-        XCTAssertEqual(c2.inRangeValue.value, -93.0)
+        #expect(c2.inRangeValue.value == -93.0)
         c2.inRangeValue.value = 7
-        XCTAssertEqual(c2.inRangeValue.value, 7)
+        #expect(c2.inRangeValue.value == 7)
         c2.inRangeValue.value += 100
-        XCTAssertEqual(c2.inRangeValue.value, 107.0)
+        #expect(c2.inRangeValue.value == 107.0)
     }
 }

--- a/Tests/EngineTests/UIKit/UIColorTests.swift
+++ b/Tests/EngineTests/UIKit/UIColorTests.swift
@@ -6,13 +6,15 @@
 //
 
 #if canImport(UIKit)
-import XCTest
+import UIKit
+import Testing
 @testable import Engine
 
-final class UIColorTests: XCTestCase {
+@Suite()
+struct UIColorTests {
 
-    func testConversionFrom32BitHexIntegerToColor() {
-
+    @Test("Conversion From 32Bit Hex-Integer To Color")
+    func conversionFrom32BitHexIntegerToColor() async throws {
         let color = UIColor(hex32: 0xffeeddcc)  // hex 32 bit initializer
         var r: CGFloat = 0
         var g: CGFloat = 0
@@ -20,14 +22,14 @@ final class UIColorTests: XCTestCase {
         var a: CGFloat = 0
         color.getRed(&r, green: &g, blue: &b, alpha: &a)
 
-        XCTAssertEqual(Int(r * 255), 255)
-        XCTAssertEqual(Int(g * 255), 238)
-        XCTAssertEqual(Int(b * 255), 221)
-        XCTAssertEqual(Int(a * 255), 204)
+        #expect(Int(r * 255) == 255)
+        #expect(Int(g * 255) == 238)
+        #expect(Int(b * 255) == 221)
+        #expect(Int(a * 255) == 204)
     }
 
-    func testConversionFrom24BitHexIntegerToColor() {
-
+    @Test("Conversion From 24Bit Hex-Integer To Color")
+    func conversionFrom24BitHexIntegerToColor() async throws {
         let color = UIColor(0xffeedd) // hex 24 bit initializer
         var r: CGFloat = 0
         var g: CGFloat = 0
@@ -35,10 +37,10 @@ final class UIColorTests: XCTestCase {
         var a: CGFloat = 0
         color.getRed(&r, green: &g, blue: &b, alpha: &a)
 
-        XCTAssertEqual(Int(r * 255), 255)
-        XCTAssertEqual(Int(g * 255), 238)
-        XCTAssertEqual(Int(b * 255), 221)
-        XCTAssertEqual(Int(a * 255), 255)
+        #expect(Int(r * 255) == 255)
+        #expect(Int(g * 255) == 238)
+        #expect(Int(b * 255) == 221)
+        #expect(Int(a * 255) == 255)
     }
 }
 #endif


### PR DESCRIPTION
- Raise min Swift version to Swift 5.10
- Move Keychain from ASCKit to here so it can be used everywhere by just typing `Engine.keychain`
- Convert all tests to SwiftTesting