### PR TITLE
Support request output types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,21 @@
 
 ## [Unreleased]
 
+* [#25](https://github.com/blackjacx/engine/pull/25): Support request output types - [@blackjacx](https://github.com/blackjacx).
+
 ## [0.2.0] - 2025-09-15Z
-* [#16](https://github.com/blackjacx/engine/pull/16): Replace Keychain Framework - [@Blackjacx](https://github.com/blackjacx).
+* [#16](https://github.com/blackjacx/engine/pull/16): Replace Keychain Framework - [@blackjacx](https://github.com/blackjacx).
 
 ## [0.1.0] - 2025-02-17Z
-* [#14](https://github.com/blackjacx/engine/pull/14): Implement Zero-Dependency JWT Generation - [@Blackjacx](https://github.com/blackjacx).
+* [#14](https://github.com/blackjacx/engine/pull/14): Implement Zero-Dependency JWT Generation - [@blackjacx](https://github.com/blackjacx).
 * Fix Testing GH Actions workflow - [@Blackjacx](https://github.com/blackjacx).
 * Moving Quickie Package here - [@Blackjacx](https://github.com/blackjacx).
 * Fix GH Actions Tests - [@Blackjacx](https://github.com/blackjacx).
 
 ## [0.0.4] - 2022-07-02Z
-* [#7](https://github.com/blackjacx/engine/pull/7): Adding DocC Documentation - [@Blackjacx](https://github.com/blackjacx).
+* [#7](https://github.com/blackjacx/engine/pull/7): Adding DocC Documentation - [@blackjacx](https://github.com/blackjacx).
 * Upgrade to Swift 5.6 - [@Blackjacx](https://github.com/blackjacx).
 
 ## [0.0.3] - 2022-03-14Z
-* [#3](https://github.com/blackjacx/engine/pull/3): Async Await Support - [@Blackjacx](https://github.com/blackjacx).
-* Implement AsyncResultOperation & ChainedAsyncResultOperation - [@Blackjacx](https://github.com/blackjacx).
+* [#3](https://github.com/blackjacx/engine/pull/3): Async Await Support - [@blackjacx](https://github.com/blackjacx).
+* Implement AsyncResultOperation & ChainedAsyncResultOperation - [@blackjacx](https://github.com/blackjacx).

--- a/Sources/Engine/Networking/Network.swift
+++ b/Sources/Engine/Networking/Network.swift
@@ -26,7 +26,19 @@ public struct Network {
 
     // MARK: - Async / Await
 
-    public func request<T: Decodable>(endpoint: Endpoint) async throws -> T {
+    
+    /// Requests a given endpoint, decoded the result into a Decodable object
+    /// which is then returned..
+    /// - Parameters:
+    ///   - endpoint: The endpoint with all needed information for the request.
+    ///   - isOutputDesired: When doing chained requests you typically only
+    ///   want to see the final result. This is used to prevent printing the
+    ///   results from intermediate requests.
+    /// - Returns: The decoded object.
+    public func request<T: Decodable>(
+        endpoint: Endpoint,
+        outputType: OutputType,
+    ) async throws -> T {
 
         let url = endpoint.buildUrl()
         let headers = await endpoint.headers()
@@ -68,6 +80,15 @@ public struct Network {
             throw NetworkError.invalidStatusCode(code: response.statusCode, underlying: error)
         }
 
+        switch outputType {
+        case .raw:
+            let json = String(data: data, encoding: .utf8)!
+            print(json)
+        case .none:
+            break
+        }
+
+        /// Verbose output may print json output redundantly
         if Self.verbosityLevel > 0 {
             let json = String(data: data, encoding: .utf8)!
             print(json)

--- a/Sources/Engine/Networking/OutputType.swift
+++ b/Sources/Engine/Networking/OutputType.swift
@@ -1,0 +1,17 @@
+//
+//  OutputType.swift
+//  Engine
+//
+//  Created by Stefan Herold on 23.10.25.
+//
+
+import Foundation
+
+/// The way the results of a network requests are displayed
+public enum OutputType: String, Codable {
+    /// The output is rendered as it is received to the console (default)
+    case raw
+    /// No output is rendered. Suitable when the frontend itself renders the
+    /// results.
+    case none
+}


### PR DESCRIPTION
The new OutputType controls the way the results of a network requests are displayed. By default the json output is rendered. In CLI tools this can be used to conveniently process the output e.g. via JQ.