### PR TITLE
feat: add invalidTokenUrl case to JWT.Error

### DIFF
--- a/Sources/Engine/JWT/JWT.swift
+++ b/Sources/Engine/JWT/JWT.swift
@@ -160,9 +160,9 @@ public struct JWT {
         case keyContainsNoData(String)
         case googleServiceAccountJsonNotFound(path: String)
         case invalidResonse(response: URLResponse)
-        /// The token URL string is malformed or cannot be converted to a valid `URL`.
-        /// - Parameter url: The invalid URL string.
-        case invalidTokenUrl(String)
+        /// The URL string is malformed or cannot be converted to a valid `URL`.
+        /// - Parameter url: The malformed URL string.
+        case malformedUrl(String)
     }
 }
 

--- a/Sources/Engine/JWT/JWT.swift
+++ b/Sources/Engine/JWT/JWT.swift
@@ -160,5 +160,7 @@ public struct JWT {
         case keyContainsNoData(String)
         case googleServiceAccountJsonNotFound(path: String)
         case invalidResonse(response: URLResponse)
+        case invalidTokenUrl(String)
     }
 }
+

--- a/Sources/Engine/JWT/JWT.swift
+++ b/Sources/Engine/JWT/JWT.swift
@@ -160,6 +160,8 @@ public struct JWT {
         case keyContainsNoData(String)
         case googleServiceAccountJsonNotFound(path: String)
         case invalidResonse(response: URLResponse)
+        /// The token URL string is malformed or cannot be converted to a valid `URL`.
+        /// - Parameter url: The invalid URL string.
         case invalidTokenUrl(String)
     }
 }


### PR DESCRIPTION
## Summary
- Adds `case invalidTokenUrl(String)` to `JWT.Error` enum to represent invalid token URL errors with an associated descriptive string

## Test plan
- [ ] Verify the new error case compiles successfully
- [ ] Use the new case where invalid token URLs are encountered

🤖 Generated with [Claude Code](https://claude.com/claude-code)