### PR TITLE
feat: add malformedUrl case to JWT.Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* [#29](https://github.com/blackjacx/engine/pull/29): feat: add malformedUrl case to JWT.Error - [@blackjacx](https://github.com/blackjacx).
+
 ## [0.3.0] - 2025-10-23Z
 
 * [#25](https://github.com/blackjacx/engine/pull/25): Support request output types - [@blackjacx](https://github.com/blackjacx).

--- a/Sources/Engine/JWT/JWT.swift
+++ b/Sources/Engine/JWT/JWT.swift
@@ -160,5 +160,9 @@ public struct JWT {
         case keyContainsNoData(String)
         case googleServiceAccountJsonNotFound(path: String)
         case invalidResonse(response: URLResponse)
+        /// The URL string is malformed or cannot be converted to a valid `URL`.
+        /// - Parameter url: The malformed URL string.
+        case malformedUrl(String)
     }
 }
+


### PR DESCRIPTION
## Summary
- Adds `case malformedUrl(String)` to `JWT.Error` enum to represent cases where a URL string is malformed or cannot be converted to a valid `URL`

## Test plan
- [x] Project compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)