### PR TITLE
Add Encodable.jsonString() helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#32](https://github.com/blackjacx/engine/pull/32): Add Encodable.jsonString() helper - [@blackjacx](https://github.com/blackjacx).
 
 ## [0.3.2] - 2026-07-21Z
 * Dependency updates - [@blackjacx](https://github.com/blackjacx).

--- a/Sources/Engine/Foundation/Encodable+JSON.swift
+++ b/Sources/Engine/Foundation/Encodable+JSON.swift
@@ -1,0 +1,24 @@
+//
+//  Encodable+JSON.swift
+//  Engine
+//
+//  Created by Stefan Herold on 21.07.26.
+//
+
+import Foundation
+
+public extension Encodable {
+
+    /// Renders the receiver as pretty printed JSON so command output stays
+    /// machine readable.
+    func jsonString() throws -> String {
+        let encoder = Json.encoder
+        encoder.outputFormatting = [
+            .prettyPrinted,
+            .sortedKeys,
+            .withoutEscapingSlashes,
+        ]
+        let data = try encoder.encode(self)
+        return String(decoding: data, as: UTF8.self)
+    }
+}


### PR DESCRIPTION
Adds a `jsonString()` helper on `Encodable` that renders the receiver as pretty-printed JSON with sorted keys and unescaped slashes, so command output stays machine readable.